### PR TITLE
Feature/featuer flag for throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ Alternatively you can include the following line in your ```composer.json``` ins
 
 Use the UTCDateTime- or UTCDateTimeImmutable-Object just like PHPs own DateTime-Objects. You do not have to rewrite any productive code. Just add ```use UTCDateTime/DateTime``` resp. ```use UTCDateTime\DateTimeimmutable``` to the ```use```-section of your PHP-file. That will cause PHP to use the UTCDateTime-Objects instead of the PHP-Internal DateTime-Objects.
 
-Calls to ```setTimeZone``` will be ignored, all other calls will be executed just as before. The only difference will be, that no matter what you put into the DateTime-Objects, it will always contain the UTC-representation of your date. And there is no way to change that.
+Calls to ```setTimeZone``` will throw a LogicException, all other calls will be executed just as before. The only difference will be, that no matter what you put into the DateTime-Objects, it will always contain the UTC-representation of your date. And there is no way to change that.
 
 So any Datetime-data will always be correctly converted to UTC and you can then work with that like so:
 
     use UTCDateTime\DateTime;
+    $date = new DateTime('2014-11-03 12:34:56', new DateTimeZone('Europe/Berlin'));
+    echo $date->format(DateTime::RFC3339);
+    // 2014-11-03T10:34:56+00:00
+
+In legacy mode calls to ```setTimeZone``` will trigger an ```E_USER_NOTICE``` instead of throwing an Exception. That way you can use it in existing code to transparently replace existing DateTime-Objects. To turn on legacy mode you have to set ```DateTime::$legacyMode = true``` before the first call to ```set TimeZone```.
+
+    use UTCDateTime\DateTime;
+    DateTime::$legacyMode = true;
     $date = new DateTime('2014-11-03 12:34:56', new DateTimeZone('Europe/Berlin'));
     echo $date->format(DateTime::RFC3339);
     // 2014-11-03T10:34:56+00:00

--- a/src/UTCDateTime/DateTime.php
+++ b/src/UTCDateTime/DateTime.php
@@ -40,7 +40,7 @@ class DateTime extends DefaultDateTime
 
     const PDF = 'YmdHis\Z';
 
-    public static $throwOnSetTimezone = true;
+    public static $legacyMode = false;
 
     /**
      * @param string       $time
@@ -63,7 +63,7 @@ class DateTime extends DefaultDateTime
      */
     public function setTimezone($timezone)
     {
-        if (self::$throwOnSetTimezone) {
+        if (! self::$legacyMode) {
             throw new \LogicException('Setting a timezone on a UTCDateTime-object doesn\'t make sense');
         }
         trigger_Error('Setting a timezone on a UTCDateTime-object doesn\'t make sense');

--- a/src/UTCDateTime/DateTimeImmutable.php
+++ b/src/UTCDateTime/DateTimeImmutable.php
@@ -60,7 +60,7 @@ class DateTimeImmutable extends DefaultDateTimeImmutable
      */
     public function setTimezone($timezone)
     {
-        if (DateTime::$throwOnSetTimezone) {
+        if (! DateTime::$legacyMode) {
             throw new \LogicException('Setting a timezone on a UTCDateTime-object doesn\'t make sense');
         }
         trigger_Error('Setting a timezone on a UTCDateTime-object doesn\'t make sense');

--- a/tests/UTCDateTimeTest/DateTimeImmutableTest.php
+++ b/tests/UTCDateTimeTest/DateTimeImmutableTest.php
@@ -41,7 +41,7 @@ class DateTimeImmutableTest extends \PHPUnit_Framework_TestCase
         if (version_compare(PHP_VERSION, '5.5', '<')) {
             $this->markTestSkipped('Skipped due to version mismatch. DateTimeImmutable does not work before PHP 5.5');
         }
-        DateTime::$throwOnSetTimezone = true;
+        DateTime::$legacyMode = false;
     }
 
     public function testCreationOfUTCDateTime()
@@ -73,7 +73,7 @@ class DateTimeImmutableTest extends \PHPUnit_Framework_TestCase
 
     public function testSettingTimezoneDoesNothing()
     {
-        DateTime::$throwOnSetTimezone = false;
+        DateTime::$legacyMode = true;
         $test = new DateTimeImmutable();
         $this->assertSame($test, @$test->setTimeZone(new \DateTimeZone('Europe/Berlin')));
         $this->assertEquals(new \DateTimeZone('UTC'), $test->getTimezone());
@@ -84,7 +84,7 @@ class DateTimeImmutableTest extends \PHPUnit_Framework_TestCase
      */
     public function testSettingTimezoneTRiggersError()
     {
-        DateTime::$throwOnSetTimezone = false;
+        DateTime::$legacyMode = true;
         $test = new DateTimeImmutable();
 
         $this->assertSame($test, $test->setTimeZone(new \DateTimeZone('Europe/Berlin')));

--- a/tests/UTCDateTimeTest/DateTimeTest.php
+++ b/tests/UTCDateTimeTest/DateTimeTest.php
@@ -37,7 +37,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 {
     public function setup()
     {
-        DateTime::$throwOnSetTimezone = true;
+        DateTime::$legacyMode = false;
     }
 
     public function testCreationOfUTCDateTime()
@@ -77,12 +77,11 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 
     public function testSettingTimezoneDoesNothing()
     {
-        DateTime::$throwOnSetTimezone = false;
+        DateTime::$legacyMode = true;
         $test = new DateTime();
 
         $this->assertSame($test, @$test->setTimeZone(new \DateTimeZone('Europe/Berlin')));
         $this->assertEquals(new \DateTimeZone('UTC'), $test->getTimezone());
-        DateTime::$throwOnSetTimezone = false;
     }
 
     /**
@@ -90,7 +89,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
      */
     public function testSettingTimezoneTriggersError()
     {
-        DateTime::$throwOnSetTimezone = false;
+        DateTime::$legacyMode = true;
         $test = new DateTime();
 
         $this->assertSame($test, $test->setTimeZone(new \DateTimeZone('Europe/Berlin')));


### PR DESCRIPTION
This PR adds a featureFlag to change behaviour for calls to `setTimeZone`. With legacyMode enabled  a call will trigger an `E_USER_NOTICE` without legacyMode a LogicExsception will be thrown
